### PR TITLE
delete tags from former schedules (PL-26155)

### DIFF
--- a/smoketest.sh
+++ b/smoketest.sh
@@ -15,8 +15,13 @@ cd ${BACKUP}/backup
 # $BACKY init file ../original
 cat > config <<EOF
 ---
-    type: file
-    filename: ../original
+    schedule:
+        daily:
+            interval: 1d
+            keep: 7
+    source:
+        type: file
+        filename: ../original
 EOF
 
 echo "Using ${BACKUP} as workspace."
@@ -31,7 +36,11 @@ echo " Done."
 
 echo -n "Backing up img_state1.img. "
 ln -sf img_state1.img ../original
-$BACKY backup test
+$BACKY backup manual:test
+echo "Done."
+
+echo -n "Backing up img_state1.img with unknown tag. "
+! $BACKY backup unknown
 echo "Done."
 
 echo -n "Restoring img_state1.img from level 0. "
@@ -53,7 +62,7 @@ rm $BACKUP/restore_*
 
 echo -n "Backing up img_state2.img. "
 ln -sf img_state2.img ../original
-$BACKY backup test
+$BACKY backup daily
 echo "Done."
 
 echo -n "Restoring img_state2.img from level 0. "
@@ -89,7 +98,7 @@ rm $BACKUP/restore_*
 
 echo -n "Backing up img_state2.img again. "
 ln -sf img_state2.img ../original
-$BACKY backup test
+$BACKY backup -f test
 echo "Done."
 
 echo -n "Restoring img_state2.img from level 0. "
@@ -139,7 +148,7 @@ rm $BACKUP/restore_*
 
 echo -n "Backing up img_state3.img. "
 ln -sf img_state3.img ../original
-$BACKY backup test
+$BACKY backup manual:test
 echo "Done."
 
 echo -n "Restoring img_state3.img from level 0. "

--- a/src/backy/conftest.py
+++ b/src/backy/conftest.py
@@ -75,7 +75,10 @@ def schedule():
 @pytest.fixture
 def backup(schedule, tmpdir):
     with open(str(tmpdir / "config"), "wb") as f:
-        f.write(b"{'type': 'file', 'filename': 'test'}")
+        f.write(
+            b"{'source': {'type': 'file', 'filename': 'test'},"
+            b"'schedule': {'daily': {'interval': '1d', 'keep': 7}}}"
+        )
     return backy.backup.Backup(str(tmpdir))
 
 

--- a/src/backy/main.py
+++ b/src/backy/main.py
@@ -52,9 +52,6 @@ class Command(object):
     def __init__(self, path):
         self.path = path
 
-    def init(self, type, source):
-        backy.backup.Backup.init(self.path, type, source)
-
     def status(self):
         b = backy.backup.Backup(self.path)
         total_bytes = 0
@@ -96,12 +93,12 @@ class Command(object):
             )
         )
 
-    def backup(self, tags):
+    def backup(self, tags, force):
         b = backy.backup.Backup(self.path)
         b._clean()
         try:
             tags = set(t.strip() for t in tags.split(","))
-            b.backup(tags)
+            b.backup(tags, force)
         except IOError as e:
             if e.errno not in [errno.EDEADLK, errno.EAGAIN]:
                 raise
@@ -177,23 +174,15 @@ def setup_argparser():
 
     subparsers = parser.add_subparsers()
 
-    # INIT
-    p = subparsers.add_parser(
-        "init",
-        help="""\
-Initialize backup for a <source> in the backup directory.
-""",
-    )
-    p.set_defaults(func="init")
-    p.add_argument("type")
-    p.add_argument("source")
-
     # BACKUP
     p = subparsers.add_parser(
         "backup",
         help="""\
 Perform a backup.
 """,
+    )
+    p.add_argument(
+        "-f", "--force", action="store_true", help="Do not validate tags"
     )
     p.add_argument("tags", help="Tags to apply to the backup.")
     p.set_defaults(func="backup")

--- a/src/backy/revision.py
+++ b/src/backy/revision.py
@@ -13,8 +13,14 @@ TRUST_TRUSTED = "trusted"
 TRUST_DISTRUSTED = "distrusted"
 TRUST_VERIFIED = "verified"
 
+TAG_MANUAL_PREFIX = "manual:"
+
 
 logger = logging.getLogger(__name__)
+
+
+def filter_schedule_tags(tags):
+    return {t for t in tags if not t.startswith(TAG_MANUAL_PREFIX)}
 
 
 class Revision(object):
@@ -22,7 +28,7 @@ class Revision(object):
     timestamp = None
     parent = None
     stats = None
-    tags = ()
+    tags = None
     trust = TRUST_TRUSTED  # or TRUST_DISTRUSTED, TRUST_VERIFIED
 
     def __init__(self, backup, uuid=None, timestamp=None):
@@ -31,6 +37,7 @@ class Revision(object):
         self.uuid = uuid if uuid else shortuuid.uuid()
         self.timestamp = timestamp if timestamp else now()
         self.stats = {"bytes_written": 0}
+        self.tags = set()
 
     @classmethod
     def create(cls, backup, tags):

--- a/src/backy/scheduler.py
+++ b/src/backy/scheduler.py
@@ -100,7 +100,9 @@ class Job(object):
         config = p.join(self.path, "config")
         with SafeFile(config, encoding="utf-8") as f:
             f.open_new("wb")
-            yaml.safe_dump(self.source, f)
+            yaml.safe_dump(
+                {"source": self.source, "schedule": self.schedule.config}, f
+            )
             if p.exists(config) and filecmp.cmp(config, f.name):
                 raise ValueError("not changed")
 

--- a/src/backy/tests/samples/simple_file/config
+++ b/src/backy/tests/samples/simple_file/config
@@ -1,3 +1,8 @@
 ---
+schedule:
+    daily:
+        interval: 1d
+        keep: 7
+source:
     type: file
     filename: input-file

--- a/src/backy/tests/test_daemon.py
+++ b/src/backy/tests/test_daemon.py
@@ -67,22 +67,22 @@ def test_fail_on_nonexistent_config():
 async def test_run_backup(daemon):
     job = daemon.jobs["test01"]
 
-    await job.run_backup(set(["asdf"]))
+    await job.run_backup({"manual:asdf"})
     job.backup.scan()
     assert len(job.backup.history) == 1
     revision = job.backup.history[0]
-    assert revision.tags == set(["asdf"])
+    assert revision.tags == {"manual:asdf"}
     backend = ChunkedFileBackend(revision)
     with backend.open("r") as f:
         assert f.read() == b"I am your father, Luke!"
 
     # Run again. This also covers the code path that works if
     # the target backup directory exists already.
-    await job.run_backup(set(["asdf"]))
+    await job.run_backup({"manual:asdf"})
     job.backup.scan()
     assert len(job.backup.history) == 2
     revision = job.backup.history[1]
-    assert revision.tags == set(["asdf"])
+    assert revision.tags == {"manual:asdf"}
     backend = ChunkedFileBackend(revision)
     with backend.open("r") as f:
         assert f.read() == b"I am your father, Luke!"

--- a/src/backy/tests/test_schedule.py
+++ b/src/backy/tests/test_schedule.py
@@ -194,17 +194,19 @@ def test_do_not_expire_if_less_than_keep_and_inside_keep_interval(
     assert [{"daily"}] * 6 == [rev.tags for rev in backup.history]
     assert not os.path.exists(r.filename + ".rev")
 
-    # If we have unknown tags, then those do not expire. However, the
-    # known tag disappears but then the file remains because there's still
-    # a tag left.
+    # If we have manual tags, then those do not expire. However, the
+    # known and unknown tag disappear but then the file remains
+    # because there's still a manual tag left.
     r = add_revision(datetime(2014, 5, 4, 11, 0, tzinfo=UTC))
-    r.tags = {"daily", "test"}
+    r.tags = {"daily", "manual:test", "unknown"}
     r.write_info()
     assert os.path.exists(r.filename + ".rev")
     expired = schedule.expire(backup)
     assert [] == [x.uuid for x in expired]
     backup.scan()
-    assert [{"test"}] + [{"daily"}] * 6 == [rev.tags for rev in backup.history]
+    assert [{"manual:test"}] + [{"daily"}] * 6 == [
+        rev.tags for rev in backup.history
+    ]
     assert os.path.exists(r.filename + ".rev")
 
 

--- a/src/backy/tests/test_source.py
+++ b/src/backy/tests/test_source.py
@@ -7,9 +7,14 @@ def test_configure_ceph_source(tmpdir):
         f.write(
             """\
 ---
-    type: ceph-rbd
-    pool: test
-    image: test04
+    schedule:
+        daily:
+            interval: 1d
+            keep: 7
+    source:
+        type: ceph-rbd
+        pool: test
+        image: test04
 """
         )
     backup = Backup(str(tmpdir))


### PR DESCRIPTION
## Release process

Impact:
- The job config format changed. The scheduler will update it automatically.
All manual tags without the `manual:` prefix will be removed.

Changelog:
- Tags are now validated against the config file. Manual tags require the `manual:` prefix. This check can be skipped with the `--force` flag.
- Remove `init` subcommand