### PR TITLE
rbd: adapt to changed JSON output in Ceph Nautilus

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -23,6 +23,9 @@ Changelog
 
 - Regularly log overdue jobs.
 
+- Adapt to changed `rbd showmapped` output format in Ceph Nautilus. Breaks
+  compatibility with older Ceph versions!
+
 2.4.3 (2019-04-17)
 ==================
 

--- a/src/backy/sources/ceph/rbd.py
+++ b/src/backy/sources/ceph/rbd.py
@@ -42,7 +42,7 @@ class RBDClient(object):
         self._rbd(['--read-only' if readonly else '', 'map', image])
 
         mappings = self._rbd(['showmapped'], format='json')
-        for mapping in mappings.values():
+        for mapping in mappings:
             if image == '{pool}/{name}@{snap}'.format(**mapping):
                 return mapping
         raise RuntimeError('Map not found in mapping list.')

--- a/src/backy/sources/ceph/tests/test_ceph_source.py
+++ b/src/backy/sources/ceph/tests/test_ceph_source.py
@@ -348,8 +348,9 @@ def test_verify_fail(check_output, backup, tmpdir, backend_factory):
         # map
         b'{}',
         # showmapped
-        '{{"rbd0": {{"pool": "test", "name": "foo", "snap": "backy-a0", \
-                    "device": "{}"}}}}'.format(rbd_source).encode('ascii'),
+        '[{{"id": "0", "pool": "test", "namespace": "", "name": "foo", \
+                    "snap": "backy-a0", \
+                    "device": "{}"}}]'.format(rbd_source).encode('ascii'),
         # unmap
         b'{}',
         # snap ls
@@ -398,8 +399,9 @@ def test_verify(check_output, backup, tmpdir, backend_factory):
         # map
         b'{}',
         # showmapped
-        '{{"rbd0": {{"pool": "test", "name": "foo", "snap": "backy-a0", \
-                    "device": "{}"}}}}'.format(rbd_source).encode('ascii'),
+        '[{{"id": "0", "pool": "test", "namespace": "", "name": "foo", \
+                    "snap": "backy-a0", \
+                    "device": "{}"}}]'.format(rbd_source).encode('ascii'),
         # unmap
         b'{}',
         # snap ls

--- a/src/backy/sources/ceph/tests/test_rbd.py
+++ b/src/backy/sources/ceph/tests/test_rbd.py
@@ -52,13 +52,16 @@ def test_rbd_nonexisting_image_turned_to_false(rbdclient):
 
 def test_rbd_map_writable(rbdclient):
     rbdclient._rbd.side_effect = [
-        None, {
-            '1': {
+        None, [
+            {
+                'id': '1',
                 'pool': 'test',
+                'namespace': "",
                 'name': 'test04.root',
-                'snap': 'backup'}}]
+                'snap': 'backup'}]]
     mapped = rbdclient.map('test/test04.root@backup')
-    assert mapped == {'pool': 'test', 'name': 'test04.root', 'snap': 'backup'}
+    assert mapped == {'id': '1', 'pool': 'test', 'namespace': "",
+                      'name': 'test04.root', 'snap': 'backup'}
     rbdclient._rbd.assert_has_calls([
         mock.call(['', 'map', 'test/test04.root@backup']),
         mock.call(['showmapped'], format='json')])
@@ -66,20 +69,23 @@ def test_rbd_map_writable(rbdclient):
 
 def test_rbd_map_readonly(rbdclient):
     rbdclient._rbd.side_effect = [
-        None, {
-            '1': {
+        None, [
+            {
+                'id': '1',
                 'pool': 'test',
+                'namespace': "",
                 'name': 'test04.root',
-                'snap': 'backup'}}]
+                'snap': 'backup'}]]
     mapped = rbdclient.map('test/test04.root@backup', readonly=True)
-    assert mapped == {'pool': 'test', 'name': 'test04.root', 'snap': 'backup'}
+    assert mapped == {'id': '1', 'pool': 'test', 'namespace': "",
+                      'name': 'test04.root', 'snap': 'backup'}
     rbdclient._rbd.assert_has_calls([
         mock.call(['--read-only', 'map', 'test/test04.root@backup']),
         mock.call(['showmapped'], format='json')])
 
 
 def test_rbd_map_writable_missing_map_no_maps(rbdclient):
-    rbdclient._rbd.side_effect = [None, {}]
+    rbdclient._rbd.side_effect = [None, []]
     with pytest.raises(RuntimeError):
         rbdclient.map('test/test04.root@backup', readonly=True)
     rbdclient._rbd.assert_has_calls([
@@ -89,11 +95,13 @@ def test_rbd_map_writable_missing_map_no_maps(rbdclient):
 
 def test_rbd_map_writable_missing_map(rbdclient):
     rbdclient._rbd.side_effect = [
-        None, {
-            'sadf': {
+        None, [
+            {
+                'id': 'sadf',
                 'pool': 'sadf',
+                'namespace': "",
                 'name': 'asdf',
-                'snap': 'asdf'}}]
+                'snap': 'asdf'}]]
     with pytest.raises(RuntimeError):
         rbdclient.map('test/test04.root@backup', readonly=True)
     rbdclient._rbd.assert_has_calls([
@@ -147,12 +155,14 @@ def test_rbd_image_reader(rbdclient, tmpdir):
     device = str(tmpdir / 'device')
     open(device, 'wb').write(b'asdf')
     rbdclient._rbd.side_effect = [
-        None, {
-            '1': {
+        None, [
+            {
+                'id': '1',
                 'device': device,
                 'pool': 'test',
+                'namespace': "",
                 'name': 'test04.root',
-                'snap': 'foo'}}, None]
+                'snap': 'foo'}], None]
     with rbdclient.image_reader('test/test04.root@foo') as f:
         assert f.name == device
     rbdclient._rbd.assert_has_calls([
@@ -165,12 +175,14 @@ def test_rbd_image_reader_explicit_closed(rbdclient, tmpdir):
     device = str(tmpdir / 'device')
     open(device, 'wb').write(b'asdf')
     rbdclient._rbd.side_effect = [
-        None, {
-            '1': {
+        None, [
+            {
+                'id': '1',
                 'device': device,
                 'pool': 'test',
+                'namespace': "",
                 'name': 'test04.root',
-                'snap': 'foo'}}, None]
+                'snap': 'foo'}], None]
     with rbdclient.image_reader('test/test04.root@foo') as f:
         f.close()
     rbdclient._rbd.assert_has_calls([


### PR DESCRIPTION
This makes backy compatible to the Ceph Nautilus client tooling: `rbd showmapped` has now a different json output. It now returns a list of objects (dicts) decribing mappings, instead of an object (dictionary) already at the top level.

At the same time, it also **breaks compatibility** with Ceph rbd versions <14.x. Thus note that merging this will cause the main branch to become incompatible to older Ceph versions.

- [x] Verified that a `backy backup` run is working again in a Ceph Nautilus cluster