### PR TITLE
fix commit hash in .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,2 @@
 # add pre-commit with black, isort and flake8 (#18)
-c81362b39746b2fc432c5be3f047cea72ce1169a
+14f0af0469bab372d6b81ca19dd72a9120649c21


### PR DESCRIPTION
rebasing #22 changed the commit hash

* [ ] Change is documented in changelog

# Security implications

none