### PR TITLE
monitor for manual tags

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -34,6 +34,8 @@ Changelog
 
 - Static typechecking with mypy
 
+- List all manual tags in `backy check`
+
 2.4.3 (2019-04-17)
 ==================
 

--- a/src/backy/revision.py
+++ b/src/backy/revision.py
@@ -26,6 +26,10 @@ def filter_schedule_tags(tags):
     return {t for t in tags if not t.startswith(TAG_MANUAL_PREFIX)}
 
 
+def filter_manual_tags(tags):
+    return {t for t in tags if t.startswith(TAG_MANUAL_PREFIX)}
+
+
 class Revision(object):
     backup: "backy.backup.Backup"
     uuid: str


### PR DESCRIPTION
closes #25

* [x] Change is documented in changelog

# Security implications

* [x] Requirement: we need to be aware of manual interventions (which manual tags are!)
  * [x] this PR makes those manual tags visible in our monitoring thus reducing risk of them getting forgotten

The change itself doesn't introduce new risks that need to be countered.