### PR TITLE
Fix crash for non-numeric Ceph version string (PL-131449)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -36,6 +36,8 @@ Changelog
 
 - List all manual tags in `backy check`
 
+- Fix crash for non-numeric Ceph version strings
+
 2.4.3 (2019-04-17)
 ==================
 

--- a/src/backy/sources/ceph/__init__.py
+++ b/src/backy/sources/ceph/__init__.py
@@ -1,22 +1,5 @@
 from subprocess import PIPE, run
 
-import packaging.version
-
-
-def get_ceph_major_version():
-    result = run(["ceph", "-v"], stdout=PIPE, stderr=PIPE, check=True)
-    version_string = result.stdout.decode("ascii").splitlines()[0]
-    version_parts = version_string.split()
-    if version_parts[:2] != ["ceph", "version"]:
-        raise ValueError("Unexpected version line: {:r}".format(version_string))
-    return packaging.version.parse(version_parts[2])
-
-
-try:
-    CEPH_VERSION = get_ceph_major_version()
-except FileNotFoundError:
-    CEPH_VERSION = packaging.version.Version("0")
-
 
 def detect_whole_object_support():
     result = run(

--- a/src/backy/sources/ceph/rbd.py
+++ b/src/backy/sources/ceph/rbd.py
@@ -113,9 +113,7 @@ class RBDClient(object):
 
     @contextlib.contextmanager
     def export_diff(self, new, old):
-        self.log.info(
-            "export-diff", ceph_version=str(backy.sources.ceph.CEPH_VERSION)
-        )
+        self.log.info("export-diff")
         if backy.sources.ceph.CEPH_RBD_SUPPORTS_WHOLE_OBJECT_DIFF:
             EXPORT_WHOLE_OBJECT = ["--whole-object"]
         else:
@@ -148,6 +146,7 @@ class RBDClient(object):
 
     @contextlib.contextmanager
     def export(self, image):
+        self.log.info("export")
         proc = subprocess.Popen(
             [RBD, "export", image, "-"],
             stdin=subprocess.DEVNULL,


### PR DESCRIPTION
Related issue(s): PL-131449

* [x] Change is documented in changelog

# Security implications
