### PR TITLE
Compute parent revision at runtime

### DIFF
--- a/changelog.d/20230703_144928_jb_PL_131601_fix_rev_parent.rst
+++ b/changelog.d/20230703_144928_jb_PL_131601_fix_rev_parent.rst
@@ -1,0 +1,1 @@
+- Compute parent revision at runtime

--- a/src/backy/backends/cowfile.py
+++ b/src/backy/backends/cowfile.py
@@ -15,10 +15,10 @@ class COWFileBackend(BackyBackend):
 
     def open(self, mode="rb"):
         if not os.path.exists(self.revision.filename):
-            if not self.revision.parent:
+            parent = self.revision.get_parent()
+            if not parent:
                 open(self.revision.filename, "wb").close()
             else:
-                parent = self.revision.backup.find(self.revision.parent)
                 cp_reflink(parent.filename, self.revision.filename)
             self.revision.writable()
         return open(self.revision.filename, mode, buffering=CHUNK_SIZE)

--- a/src/backy/revision.py
+++ b/src/backy/revision.py
@@ -34,7 +34,6 @@ class Revision(object):
     backup: "backy.backup.Backup"
     uuid: str
     timestamp: datetime.datetime
-    parent: Optional[str] = None
     stats: dict
     tags: set[str]
     trust: Trust = Trust.TRUSTED
@@ -53,8 +52,6 @@ class Revision(object):
     def create(cls, backup, tags, log):
         r = Revision(backup, log)
         r.tags = tags
-        if backup.history:
-            r.parent = backup.history[-1].uuid
         r.backend_type = backup.backend_type
         return r
 
@@ -73,7 +70,6 @@ class Revision(object):
         r = Revision(
             backup, log, uuid=metadata["uuid"], timestamp=metadata["timestamp"]
         )
-        r.parent = metadata["parent"]
         r.stats = metadata.get("stats", {})
         r.tags = set(metadata.get("tags", []))
         # Assume trusted by default to support migration
@@ -102,7 +98,9 @@ class Revision(object):
             "uuid": self.uuid,
             "backend_type": self.backend_type,
             "timestamp": self.timestamp,
-            "parent": self.parent,
+            "parent": getattr(
+                self.get_parent(), "uuid", ""
+            ),  # compatibility with older versions
             "stats": self.stats,
             "trust": self.trust.value,
             "tags": list(self.tags),
@@ -145,7 +143,11 @@ class Revision(object):
             os.chmod(self.filename, 0o440)
         os.chmod(self.info_filename, 0o440)
 
-    def get_parent(self):
-        if self.parent:
-            return self.backup.find_by_uuid(self.parent)
-        return
+    def get_parent(self) -> Optional["Revision"]:
+        """defaults to last rev if not in history"""
+        prev = None
+        for r in self.backup.history:
+            if r.uuid == self.uuid:
+                break
+            prev = r
+        return prev

--- a/src/backy/sources/ceph/source.py
+++ b/src/backy/sources/ceph/source.py
@@ -71,22 +71,22 @@ class CephRBD(BackySource, BackySourceFactory, BackySourceContext):
             return
         revision = self.revision
         while True:
-            if not revision.parent:
+            parent = revision.get_parent()
+            if not parent:
                 self.log.info("backup-no-valid-parent")
                 self.full(target)
                 return
-            parent = self.revision.backup.find(revision.parent)
             if parent.trust == Trust.DISTRUSTED:
                 self.log.info(
                     "ignoring-distrusted-rev",
-                    revision_uuid=revision.parent,
+                    revision_uuid=parent.uuid,
                 )
                 revision = parent
                 continue
             if not self.rbd.exists(self._image_name + "@backy-" + parent.uuid):
                 self.log.info(
                     "ignoring-rev-without-snapshot",
-                    revision_uuid=revision.parent,
+                    revision_uuid=parent.uuid,
                 )
                 revision = parent
                 continue

--- a/src/backy/tests/test_archive.py
+++ b/src/backy/tests/test_archive.py
@@ -56,7 +56,9 @@ def test_load_revisions(backup_with_revisions):
     a = backup_with_revisions
     assert [x.uuid for x in a.history] == ["123-0", "123-1", "123-2"]
     assert a.history[1].uuid == "123-1"
-    assert a.history[1].parent == "123-0"
+    assert a.history[1].get_parent().uuid == "123-0"
+    assert a.history[2].get_parent().uuid == "123-1"
+    assert a.history[0].get_parent() is None
     assert a.find_revisions("all") == a.history
     assert a.find_revisions(1) == [a.find(1)]
 


### PR DESCRIPTION
The `parent` attribute was never updated after creating the Revision. This could result in errors when the parent revision no longer exists.

The `parent` attribute is still stored in the `.rev` file for backwards compatibility with older backy versions.

Related issue(s): PL-131607

* [x] Change is documented in changelog

# Security implications
