### PR TITLE
remove unused `last` symlink

### DIFF
--- a/changelog.d/20230703_164348_jb_remove_last_symlink.rst
+++ b/changelog.d/20230703_164348_jb_remove_last_symlink.rst
@@ -1,0 +1,1 @@
+- Remove the `last` and `last.rev` symlink

--- a/src/backy/backup.py
+++ b/src/backy/backup.py
@@ -200,6 +200,12 @@ class Backup(object):
                 )
                 raise RuntimeError("Unknown tags")
 
+        try:  # cleanup old symlinks
+            os.unlink(p.join(self.path, "last"))
+            os.unlink(p.join(self.path, "last.rev"))
+        except OSError:
+            pass
+
         start = time.time()
 
         if not self.source.ready():
@@ -228,7 +234,6 @@ class Backup(object):
                 self.log.info(
                     "verification-ok", revision_uuid=new_revision.uuid
                 )
-                new_revision.set_link("last")
                 new_revision.stats["duration"] = time.time() - start
                 new_revision.write_info()
                 new_revision.readonly()

--- a/src/backy/revision.py
+++ b/src/backy/revision.py
@@ -11,7 +11,7 @@ from structlog.stdlib import BoundLogger
 
 import backy.backup
 
-from .utils import SafeFile, now, safe_symlink
+from .utils import SafeFile, now
 
 TAG_MANUAL_PREFIX = "manual:"
 
@@ -110,11 +110,6 @@ class Revision(object):
         with SafeFile(self.info_filename, encoding="utf-8") as f:
             f.open_new("wb")
             yaml.safe_dump(metadata, f)
-
-    def set_link(self, name):
-        path = self.backup.path
-        safe_symlink(self.filename, p.join(path, name))
-        safe_symlink(self.info_filename, p.join(path, name + ".rev"))
 
     def distrust(self):
         self.log.info("distrusted")

--- a/src/backy/utils.py
+++ b/src/backy/utils.py
@@ -198,19 +198,6 @@ class SafeFile(object):
         return self.f.fileno()
 
 
-def safe_symlink(realfile, link):
-    """Set a symlink unconditionally.
-
-    If the link used to exit before, replace it. Make the symlink
-    relative if possible.
-    """
-    try:
-        os.unlink(link)
-    except OSError:
-        pass
-    os.symlink(os.path.relpath(realfile, os.path.dirname(link)), link)
-
-
 if hasattr(os, "posix_fadvise"):
     posix_fadvise = os.posix_fadvise
 else:  # pragma: no cover


### PR DESCRIPTION
this is not used anywhere and was not updated in every case (e.g. `forget` on the last revision)
an operator can still manually inspect the `.rev` json and sort by the timestamp

* [x] Change is documented in changelog

# Security implications
