### PR TITLE
Keep flake compatible with nixpkgs-23.05

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -45,4 +45,9 @@ jobs:
 
       - name: check flake
         run: |
+          nix run
           nix flake check -L
+
+      - name: check 23.05
+        run: |
+          nix run --override-input nixpkgs github:NixOS/nixpkgs/nixos-23.05

--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1693060755,
-        "narHash": "sha256-KNsbfqewEziFJEpPR0qvVz4rx0x6QXxw1CcunRhlFdk=",
+        "lastModified": 1695806987,
+        "narHash": "sha256-fX5kGs66NZIxCMcpAGIpxuftajHL8Hil1vjHmjjl118=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c66ccfa00c643751da2fd9290e096ceaa30493fc",
+        "rev": "f3dab3509afca932f3f4fd0908957709bb1c1f57",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -9,68 +9,29 @@
     let
       supportedSystems = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
       forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
-      pkgs = forAllSystems (system: nixpkgs.legacyPackages.${system});
-      poetryOverrides = pkgs: [
-        # https://github.com/nix-community/poetry2nix/pull/899#issuecomment-1620306977
-        pkgs.poetry2nix.defaultPoetryOverrides
-        (self: super: {
-          python-lzo = super.python-lzo.overrideAttrs (old: {
-            buildInputs = (old.buildInputs or []) ++ [ pkgs.lzo ];
-          });
-          scriv = super.scriv.overrideAttrs (old: {
-            buildInputs = (old.buildInputs or []) ++ [ super.setuptools ];
-          });
-          telnetlib3 = super.telnetlib3.overrideAttrs (old: {
-            buildInputs = (old.buildInputs or []) ++ [ super.setuptools ];
-          });
-          execnet = super.execnet.overrideAttrs (old: {
-            buildInputs = (old.buildInputs or []) ++ [ super.hatchling super.hatch-vcs ];
-          });
-          consulate-fc-nix-test = super.consulate-fc-nix-test.overrideAttrs (old: {
-            buildInputs = (old.buildInputs or []) ++ [ super.setuptools super.setuptools-scm ];
-          });
-        })
-      ];
-      poetryEnv = pkgs: pkgs.poetry2nix.mkPoetryEnv {
-        projectDir = self;
-        python = pkgs.python310;
-        overrides = poetryOverrides pkgs;
-        editablePackageSources = {
-          backy = ./src;
-        };
-      };
-    in
-    {
-      packages = forAllSystems (system: {
-        default = pkgs.${system}.poetry2nix.mkPoetryApplication {
-          projectDir = self;
-          doCheck = true;
-          python = pkgs.${system}.python310;
-          overrides = poetryOverrides pkgs.${system};
-        };
-
-        venv = poetryEnv pkgs.${system};
-      });
-
-      devShells = forAllSystems (system: {
-        default = pkgs.${system}.mkShellNoCC {
-          BACKY_CMD = "backy";
-          packages = with pkgs.${system}; [
-            (poetryEnv pkgs.${system})
-            poetry
+      #pkgs = forAllSystems (system: nixpkgs.legacyPackages.${system});
+      pkgs = forAllSystems (system: import nixpkgs {
+        inherit system;
+        config = {
+          permittedInsecurePackages = [
+            "python3.10-requests-2.28.2"
+            "python3.10-requests-2.29.0"
           ];
         };
       });
+      lib = forAllSystems (system: pkgs.${system}.callPackage "${self}/lib.nix" {});
+    in
+    {
+      packages = forAllSystems (system:
+        lib.${system}.packages
+      );
 
-      checks = forAllSystems (system: {
-        pytest = pkgs.${system}.runCommand "pytest" {
-          nativeBuildInputs = [ (poetryEnv pkgs.${system}) ];
-        } ''
-          export BACKY_CMD=backy
-          cd ${self}
-          pytest -vv -p no:cacheprovider --no-cov
-          touch $out
-        '';
-      });
+      devShells = forAllSystems (system:
+        lib.${system}.devShells
+      );
+
+      checks = forAllSystems (system:
+        lib.${system}.checks
+      );
     };
 }

--- a/lib.nix
+++ b/lib.nix
@@ -1,0 +1,83 @@
+{
+  poetry2nix,
+  lzo,
+  python310,
+  mkShellNoCC,
+  poetry,
+  runCommand,
+  ...
+}:
+let
+  poetryOverrides = [
+    # https://github.com/nix-community/poetry2nix/pull/899#issuecomment-1620306977
+    poetry2nix.defaultPoetryOverrides
+    (self: super: {
+      python-lzo = super.python-lzo.overrideAttrs (old: {
+        buildInputs = (old.buildInputs or []) ++ [ lzo ];
+      });
+      scriv = super.scriv.overrideAttrs (old: {
+        buildInputs = (old.buildInputs or []) ++ [ super.setuptools ];
+      });
+      telnetlib3 = super.telnetlib3.overrideAttrs (old: {
+        buildInputs = (old.buildInputs or []) ++ [ super.setuptools ];
+      });
+      execnet = super.execnet.overrideAttrs (old: {
+        buildInputs = (old.buildInputs or []) ++ [ super.hatchling super.hatch-vcs ];
+      });
+      attrs = super.attrs.overrideAttrs (old: {
+        buildInputs = (old.buildInputs or []) ++ [ super.hatchling super.hatch-vcs super.hatch-fancy-pypi-readme ];
+      });
+      urllib3 = super.urllib3.overrideAttrs (old: {
+        buildInputs = (old.buildInputs or []) ++ [ super.hatchling super.hatch-vcs ];
+      });
+      consulate-fc-nix-test = super.consulate-fc-nix-test.overrideAttrs (old: {
+        buildInputs = (old.buildInputs or []) ++ [ super.setuptools super.setuptools-scm ];
+      });
+      shortuuid = super.shortuuid.overrideAttrs (old: {
+        # replace poetry to avoid dependency on vulnerable python-cryptography package
+        nativeBuildInputs = [ super.poetry-core ] ++ builtins.filter (p: p.pname or "" != "poetry") old.nativeBuildInputs;
+      });
+    })
+  ];
+  poetryEnv = poetry2nix.mkPoetryEnv {
+    projectDir = ./.;
+    python = python310;
+    overrides = poetryOverrides;
+    editablePackageSources = {
+      backy = ./src;
+    };
+  };
+  poetryApplication = poetry2nix.mkPoetryApplication {
+      projectDir = ./.;
+      doCheck = true;
+      python = python310;
+      overrides = poetryOverrides;
+    };
+in
+{
+  packages = {
+    default = poetryApplication;
+    venv = poetryEnv;
+  };
+
+  devShells = {
+    default = mkShellNoCC {
+      BACKY_CMD = "backy";
+      packages = [
+        poetryEnv
+        poetry
+      ];
+    };
+  };
+
+  checks = {
+    pytest = runCommand "pytest" {
+      nativeBuildInputs = [ poetryEnv ];
+    } ''
+      export BACKY_CMD=${poetryApplication}/bin/backy
+      cd ${./.}
+      pytest -vv -p no:cacheprovider --no-cov
+      touch $out
+    '';
+  };
+}


### PR DESCRIPTION
simplifies integration with fc-nixos

Related issue(s): PL-131758

* [ ] Change is documented in changelog

# Security implications

* Allows insecure packages because nixpkgs-unstable and 23.05 currently have a vulnerable version of python-requests (CVE-2023-32681; should not be relevant to us)