### PR TITLE
Fix telnet jobs command

### DIFF
--- a/changelog.d/20231012_131825_jb_issue_56_telnet_jobs_hangs.rst
+++ b/changelog.d/20231012_131825_jb_issue_56_telnet_jobs_hangs.rst
@@ -1,0 +1,3 @@
+.. A new scriv changelog fragment.
+
+- Fix telnet `jobs` command

--- a/src/backy/daemon.py
+++ b/src/backy/daemon.py
@@ -431,10 +431,10 @@ class SchedulerShell(object):
                 "SLA",
                 "SLA overdue",
                 "Status",
-                f"Last Backup ({tz.zone})",
+                f"Last Backup ({tz})",
                 "Last Tags",
                 "Last Duration",
-                f"Next Backup ({tz.zone})",
+                f"Next Backup ({tz})",
                 "Next Tags",
             ]
         )


### PR DESCRIPTION
tzlocal 5.0 dropped the pytz compatibility layer

fixes #56 

bug was introduced by #52 
not adding tests for that because telnet will be removed soonish

* [x] Change is documented in changelog

# Security implications
