### PR TITLE
Fix return code for backy backup

### DIFF
--- a/changelog.d/20240607_123138_jb_fix_backup_rc.rst
+++ b/changelog.d/20240607_123138_jb_fix_backup_rc.rst
@@ -1,0 +1,3 @@
+.. A new scriv changelog fragment.
+
+- Fixed the return code for `backy backup` which could have caused an infinite loop in the scheduler

--- a/src/backy/backup.py
+++ b/src/backy/backup.py
@@ -322,7 +322,7 @@ class Backup(object):
 
     @locked(target=".backup", mode="exclusive")
     @locked(target=".purge", mode="shared")
-    def backup(self, tags: set[str], force: bool = False) -> None:
+    def backup(self, tags: set[str], force: bool = False) -> bool:
         if not force:
             self.validate_tags(tags)
 
@@ -381,6 +381,7 @@ class Backup(object):
                 self.log.warning("inconsistent")
                 revision.backend.verify()
                 break
+        return verified
 
     @locked(target=".backup", mode="exclusive")
     def distrust(self, revision: str) -> None:

--- a/src/backy/main.py
+++ b/src/backy/main.py
@@ -97,16 +97,18 @@ class Command(object):
                 f"[yellow]{pending_changes} pending change(s)[/] (Push changes with `backy push`)"
             )
 
-    def backup(self, tags: str, force: bool) -> None:
+    def backup(self, tags: str, force: bool) -> int:
         b = Backup(self.path, self.log)
         b._clean()
         try:
             tags_ = set(t.strip() for t in tags.split(","))
-            b.backup(tags_, force)
+            success = b.backup(tags_, force)
+            return int(not success)
         except IOError as e:
             if e.errno not in [errno.EDEADLK, errno.EAGAIN]:
                 raise
-            self.log.info("backup-already-running")
+            self.log.warning("backup-already-running")
+            return 1
         finally:
             b._clean()
 


### PR DESCRIPTION
This could cause a loop without a backoff in the scheduler

Related issue(s): PL-132625

* [x] Change is documented in changelog

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

Bug fix only, improves reliabilty.

- [x] Security requirements tested? (EVIDENCE)

Added automated test coverage.