### PR TITLE
Ignore currently running backup for SLA calculation

### DIFF
--- a/changelog.d/20240612_121019_jb_running_backup_sla.rst
+++ b/changelog.d/20240612_121019_jb_running_backup_sla.rst
@@ -1,0 +1,3 @@
+.. A new scriv changelog fragment.
+
+- Ignore currently running backups for SLA calculation

--- a/src/backy/scheduler.py
+++ b/src/backy/scheduler.py
@@ -91,8 +91,6 @@ class Job(object):
         """Amount of time the SLA is currently overdue."""
         if not self.backup.clean_history:
             return 0
-        if self.status.startswith("running"):
-            return 0
         age = backy.utils.now() - self.backup.clean_history[-1].timestamp
         max_age = min(x["interval"] for x in self.schedule.schedule.values())
         if age > max_age * 1.5:

--- a/src/backy/tests/test_daemon.py
+++ b/src/backy/tests/test_daemon.py
@@ -250,6 +250,12 @@ def test_sla_over_time(daemon, clock, tmp_path, log):
     job.backup.scan()
     assert job.sla is False
 
+    # a running backup does not influence this.
+    job.update_status("running (slow)")
+    r = Revision.create(job.backup, {"daily"}, log)
+    r.write_info()
+    assert job.sla is False
+
 
 def test_incomplete_revs_dont_count_for_sla(daemon, clock, tmp_path, log):
     job = daemon.jobs["test01"]


### PR DESCRIPTION
This was already the case (due to a bug) for a long time, but was recently fixed in #37.
This commit reintroduces this behaviour.

The reasoning is that a backup which takes longer than 50% (grace period) of the configured interval indicates a problem with the backup server/network/etc...

Related issue(s): PL-132625

* [x] Change is documented in changelog

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
