### PR TITLE
[2.5.X] bug fixes

### DIFF
--- a/changelog.d/20250205_130445_jb_2_5_bug_fixes.rst
+++ b/changelog.d/20250205_130445_jb_2_5_bug_fixes.rst
@@ -1,0 +1,7 @@
+.. A new scriv changelog fragment.
+
+- truncate on full export
+- correctly discard dirty chunks on truncate
+- more efficiently fill empty blocks on truncate
+- check returncode for rbd export(-diff)
+- also check the size when verifying backups

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -12,7 +12,6 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import os
 import importlib.metadata
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -111,7 +110,7 @@ html_theme_options = {
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-html_title = "{} {}".format(project, version)
+html_title = "{} {}".format(project, release)
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
 # html_short_title = None

--- a/src/backy/backends/chunked/file.py
+++ b/src/backy/backends/chunked/file.py
@@ -163,40 +163,56 @@ class File(object):
         if position < 0:
             raise ValueError("Can not seek before the beginning of a file.")
         if position > self.size:
-            # Fill up the missing parts with zeroes.
-            target = position
-            self.seek(self.size)
-            # This is not performance optimized at all. We could do some
-            # lower-level magic to avoid copying data all over all the time.
-            # Ideally we would fill up the last existing chunk and then
-            # just inject the well-known "zero chunk" into the map.
-            filler = position - self.size
-            while filler > 0:
-                chunk = min(filler, 4 * 1024 * 1024) * b"\00"
-                filler = filler - len(chunk)
-                self.write(chunk)
-
-            # Filling up should have caused our position to have moved properly
-            # and the size also reflecting this already.
-            assert self._position == target
-            assert self.size == target
+            self.truncate(position)
 
         self._position = position
         return position
 
-    def truncate(self, size=None):
+    def truncate(self, target=None, /):
         assert "w" in self.mode and not self.closed
-        if size is None:
-            size = self._position
-        # Update content hash
-        self.size = size
+        if target is None:
+            target = self._position
         # Remove chunks past the size
         to_remove = set(
-            key for key in self._mapping if key * Chunk.CHUNK_SIZE > size
+            key
+            for key in set(self._mapping) | set(self._chunks)
+            if key * Chunk.CHUNK_SIZE >= target
         )
         for key in to_remove:
-            del self._mapping[key]
-        self.flush()
+            self._mapping.pop(key, None)
+            self._chunks.pop(key, None)
+
+        # Fill up the missing parts with zeroes.
+        orig_pos = self._position
+        self._position = self.size
+
+        if target > self._position:
+            # fill first chunk
+            data = min(target - self._position, Chunk.CHUNK_SIZE) * b"\00"
+            chunk, offset = self._current_chunk()
+            written, _ = chunk.write(offset, data)
+            self._position += written
+
+        if target > self._position:
+            chunk, offset = self._current_chunk()
+            assert offset == 0
+            written, _ = chunk.write(offset, Chunk.CHUNK_SIZE * b"\00")
+            assert written == Chunk.CHUNK_SIZE
+            self._position += Chunk.CHUNK_SIZE
+            chunk.flush()
+            empty_chunk_hash = self._mapping[chunk.id]
+
+            while target > self._position:
+                chunk_id = self._position // Chunk.CHUNK_SIZE
+                self._mapping[chunk_id] = empty_chunk_hash
+                self._position += Chunk.CHUNK_SIZE
+
+        # Filling up should have caused our position to have moved properly.
+        # Note that we will always fill full chunks. This is safe as data after
+        # the size limit can not be revealed.
+        assert self._position >= target
+        self._position = orig_pos
+        self.size = target
 
     def read(self, size=-1):
         assert "r" in self.mode and not self.closed

--- a/src/backy/backends/chunked/tests/test_file.py
+++ b/src/backy/backends/chunked/tests/test_file.py
@@ -211,7 +211,7 @@ def test_truncate(tmpdir, log):
 
     f = File(str(tmpdir / "asdf"), store)
     for i in range(5):
-        # Write 20 chunks
+        # Write 5 chunks
         chunk = b" " * Chunk.CHUNK_SIZE
         f.write(chunk)
 
@@ -226,6 +226,44 @@ def test_truncate(tmpdir, log):
     # Interesting optimization: truncating re-uses the existing
     # chunk and only limits how much we read from it.
     assert f._mapping == {0: space_hash}
+    f.close()
+
+
+def test_truncate_dirty(tmpdir, log):
+    store = Store(str(tmpdir), log)
+
+    f = File(str(tmpdir / "asdf"), store)
+    for i in range(5):
+        # Write 5 chunks
+        chunk = b" " * Chunk.CHUNK_SIZE
+        f.write(chunk)
+
+    # not flushed
+    assert f._mapping == {}
+
+    f.truncate(Chunk.CHUNK_SIZE)
+    f.seek(0)
+    assert f.read() == b" " * Chunk.CHUNK_SIZE
+    space_hash = "c01b5d75bfe6a1fa5bca6e492c5ab09a"
+
+    # update _mapping
+    f.flush()
+    assert f._mapping == {0: space_hash}
+    f.close()
+
+
+def test_truncate_increase(tmpdir, log):
+    store = Store(str(tmpdir), log)
+
+    f = File(str(tmpdir / "asdf"), store)
+    assert f.read() == b""
+
+    f.write(b"asdf")
+    f.seek(0)
+
+    f.truncate(20 + Chunk.CHUNK_SIZE)
+    assert f.tell() == 0
+    assert f.read() == b"asdf" + b"\00" * (Chunk.CHUNK_SIZE + 20 - 4)
     f.close()
 
 

--- a/src/backy/sources/ceph/diff.py
+++ b/src/backy/sources/ceph/diff.py
@@ -137,8 +137,7 @@ class RBDDiffV1(object):
 
         for record in self.read_metadata():
             if isinstance(record, SnapSize):
-                target.seek(record.size)
-                target.truncate()
+                target.truncate(record.size)
             elif isinstance(record, FromSnap):
                 assert record.snapshot == snapshot_from
             elif isinstance(record, ToSnap):

--- a/src/backy/sources/ceph/source.py
+++ b/src/backy/sources/ceph/source.py
@@ -96,12 +96,11 @@ class CephRBD(BackySource, BackySourceFactory, BackySourceContext):
         self.diff(target, parent)
 
     def diff(self, target, parent):
-        self.log.info("diff")
         snap_from = "backy-" + parent.uuid
         snap_to = "backy-" + self.revision.uuid
+        self.log.info("diff", from_=snap_from, to=snap_to)
         s = self.rbd.export_diff(self._image_name + "@" + snap_to, snap_from)
-        t = target.open("r+b")
-        with s as source, t as target:
+        with s as source, target.open("r+b") as target:
             bytes = source.integrate(target, snap_from, snap_to)
         self.log.info("diff-integration-finished")
 
@@ -123,6 +122,7 @@ class CephRBD(BackySource, BackySourceFactory, BackySourceContext):
             while True:
                 buf = source.read(4 * backy.utils.MiB)
                 if not buf:
+                    target.truncate()
                     break
                 target.write(buf)
                 copied += len(buf)

--- a/src/backy/tests/test_utils.py
+++ b/src/backy/tests/test_utils.py
@@ -283,12 +283,25 @@ def test_roughly_compare_files_1_changed_block(tmpdir):
         f.write(b"asdf" * 100)
 
     detected = 0
-    for x in range(20):
-        detected += files_are_roughly_equal(
+    for x in range(200):
+        detected += not files_are_roughly_equal(
             open("a", "rb"), open("b", "rb"), blocksize=10
         )
 
-    assert detected > 0 and detected <= 20
+    assert 0 < detected <= 200
+
+
+def test_roughly_compare_files_size_mismatch(tmpdir):
+    os.chdir(str(tmpdir))
+    with open("a", "wb") as f:
+        f.write(b"asdf" * 100)
+        f.write(b"bsdf")
+    with open("b", "wb") as f:
+        f.write(b"asdf" * 100)
+
+    assert not files_are_roughly_equal(
+        open("a", "rb"), open("b", "rb"), blocksize=10
+    )
 
 
 def test_roughly_compare_files_timeout(tmpdir):

--- a/src/backy/utils.py
+++ b/src/backy/utils.py
@@ -373,8 +373,18 @@ def files_are_roughly_equal(
     timeout=5 * 60,
     report: Callable[[bytes, bytes, int], None] = lambda a, b, c: None,
 ) -> bool:
-    a.seek(0, os.SEEK_END)
-    size = a.tell()
+    size = a.seek(0, os.SEEK_END)
+    if size != (size_b := b.seek(0, os.SEEK_END)):
+        log.error(
+            "files-roughly-equal-size-mismatch",
+            size_a=size,
+            size_b=size_b,
+        )
+        min_size = min(size, size_b)
+        a.seek(min_size)
+        b.seek(min_size)
+        report(a.read(blocksize), b.read(blocksize), min_size)  # size mismatch
+        return False
     blocks = size // blocksize
     blocklist = range(0, max(blocks, 1))
     sample = random.sample(blocklist, max(int(samplesize * blocks), 1))


### PR DESCRIPTION
Related issue(s): PL-133195

- truncate on full export
- correctly discard dirty chunks on truncate
- more efficiently fill empty blocks on truncate
- check returncode for rbd export(-diff)
- also check the size when verifying backups


* [x] Change is documented in changelog

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - fixed bugs
- [x] Security requirements tested? (EVIDENCE)
  - added unit tests