### PR TITLE
[main] bug fixes

### DIFF
--- a/changelog.d/20250205_130445_jb_2_5_bug_fixes.rst
+++ b/changelog.d/20250205_130445_jb_2_5_bug_fixes.rst
@@ -1,0 +1,7 @@
+.. A new scriv changelog fragment.
+
+- truncate on full export
+- correctly discard dirty chunks on truncate
+- more efficiently fill empty blocks on truncate
+- check returncode for rbd export(-diff)
+- also check the size when verifying backups

--- a/src/backy/rbd/__init__.py
+++ b/src/backy/rbd/__init__.py
@@ -511,9 +511,9 @@ class CephRBD:
             return parent
 
     def diff(self, target: File, parent: Revision) -> None:
-        self.log.info("diff")
         snap_from = "backy-" + parent.uuid
         snap_to = "backy-" + self.revision.uuid
+        self.log.info("diff", from_=snap_from, to=snap_to)
         s = self.rbd.export_diff(self._image_name + "@" + snap_to, snap_from)
         with s as source:
             source.integrate(target, snap_from, snap_to)
@@ -527,6 +527,7 @@ class CephRBD:
         with s as source:
             while buf := source.read(4 * backy.utils.MiB):
                 target.write(buf)
+        target.truncate()
 
     def verify(
         self,

--- a/src/backy/rbd/tests/test_rbd.py
+++ b/src/backy/rbd/tests/test_rbd.py
@@ -100,7 +100,9 @@ def test_rbd_export_diff(popen, rbdclient, tmp_path):
     stdout = open(str(tmp_path / "foobar"), "wb+")
     stdout.write(RBDDiffV1.header)
     stdout.seek(0)
-    popen.return_value = mock.Mock(stdout=stdout)
+    popen.return_value = mock.Mock(
+        stdout=stdout, wait=mock.Mock(return_value=0)
+    )
     with rbdclient.export_diff("test/test04.root@new", "old") as diff:
         assert isinstance(diff, RBDDiffV1)
     popen.assert_has_calls(
@@ -142,13 +144,15 @@ def test_rbd_image_reader_explicit_closed(rbdclient, tmp_path):
 @mock.patch("subprocess.Popen")
 def test_rbd_export(popen, rbdclient, tmp_path):
     stdout = open(str(tmp_path / "rbd0"), "wb+")
-    popen.return_value = mock.Mock(stdout=stdout)
-    with rbdclient.export(mock.sentinel.image) as f:
+    popen.return_value = mock.Mock(
+        stdout=stdout, wait=mock.Mock(return_value=0)
+    )
+    with rbdclient.export("asdf") as f:
         assert f == stdout
     popen.assert_has_calls(
         [
             mock.call(
-                [RBD, "export", mock.sentinel.image, "-"],
+                [RBD, "export", "asdf", "-"],
                 stdin=subprocess.DEVNULL,
                 stdout=subprocess.PIPE,
                 bufsize=mock.ANY,

--- a/src/backy/tests/test_utils.py
+++ b/src/backy/tests/test_utils.py
@@ -287,12 +287,25 @@ def test_roughly_compare_files_1_changed_block(tmp_path):
         f.write(b"asdf" * 100)
 
     detected = 0
-    for x in range(20):
-        detected += files_are_roughly_equal(
+    for x in range(200):
+        detected += not files_are_roughly_equal(
             open("a", "rb"), open("b", "rb"), blocksize=10
         )
 
-    assert detected > 0 and detected <= 20
+    assert 0 < detected <= 200
+
+
+def test_roughly_compare_files_size_mismatch(tmp_path):
+    os.chdir(str(tmp_path))
+    with open("a", "wb") as f:
+        f.write(b"asdf" * 100)
+        f.write(b"bsdf")
+    with open("b", "wb") as f:
+        f.write(b"asdf" * 100)
+
+    assert not files_are_roughly_equal(
+        open("a", "rb"), open("b", "rb"), blocksize=10
+    )
 
 
 def test_roughly_compare_files_timeout(tmp_path):


### PR DESCRIPTION
- truncate on full export
- correctly discard dirty chunks on truncate
- more efficiently fill empty blocks on truncate
- check returncode for rbd export(-diff)
- also check the size when verifying backups

Related issue(s): PL-133195
port of #74 

* [x] Change is documented in changelog

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - bug fixes
- [x] Security requirements tested? (EVIDENCE)
  - added unit tests
