### PR TITLE
[2.5.x] add BACKY_DEBUG env

### DIFF
--- a/changelog.d/20250818_140720_jb_debug.rst
+++ b/changelog.d/20250818_140720_jb_debug.rst
@@ -1,0 +1,3 @@
+.. A new scriv changelog fragment.
+
+- Add BACKY_DEBUG env (PL-133638)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ output_file = "CHANGES.txt"
 version = "literal: pyproject.toml: tool.poetry.version"
 entry_title_template = "{% if version %}{{ version }} {% endif %}({{ date.strftime('%Y-%m-%d') }})"
 categories = ""
+format = "rst"
 
 
 [tool.pytest.ini_options]

--- a/src/backy/logging.py
+++ b/src/backy/logging.py
@@ -3,6 +3,7 @@
 # repository for complete details.
 
 import io
+import logging
 import os
 import string
 import sys
@@ -330,7 +331,12 @@ def init_logging(
     verbose: bool,
     logfile: Optional[Path] = None,
     default_job_name: str = "",
+    trace=False,
 ):
+    TRACE = 3
+
+    structlog.stdlib.LEVEL_TO_NAME[TRACE] = "trace"
+    structlog.stdlib.NAME_TO_LEVEL["trace"] = TRACE
 
     console_file_renderer = ConsoleFileRenderer(
         min_level="trace" if verbose else "info",
@@ -356,7 +362,9 @@ def init_logging(
 
     structlog.configure(
         processors=processors,
-        wrapper_class=structlog.stdlib.BoundLogger,
+        wrapper_class=structlog._native._make_filtering_bound_logger(
+            TRACE if trace else logging.DEBUG
+        ),
         logger_factory=MultiOptimisticLoggerFactory(**loggers),
         cache_logger_on_first_use=False,
     )

--- a/src/backy/main.py
+++ b/src/backy/main.py
@@ -15,7 +15,7 @@ from structlog.stdlib import BoundLogger
 
 import backy.backup
 import backy.daemon
-from backy.utils import format_datetime_local
+from backy.utils import DEBUG, format_datetime_local
 
 from . import logging
 
@@ -334,9 +334,11 @@ def main():
         args.verbose,
         args.logfile or default_logfile,
         default_job_name="-" if is_daemon else "",
+        trace=DEBUG,
     )
     log = structlog.stdlib.get_logger(subsystem="command")
     log.debug("invoked", args=" ".join(sys.argv))
+    log.trace("tracing-enabled")
 
     command = Command(args.backupdir, log)
     func = getattr(command, args.func)

--- a/src/backy/revision.py
+++ b/src/backy/revision.py
@@ -1,7 +1,7 @@
 import datetime
 import glob
 import os
-import os.path as p
+import shutil
 from enum import Enum
 from typing import Optional
 
@@ -129,6 +129,12 @@ class Revision(object):
 
         if self in self.backup.history:
             self.backup.history.remove(self)
+
+    def archive(self, path):
+        self.log.info("archive")
+        for filename in glob.glob(self.filename + "*"):
+            if os.path.exists(filename):
+                shutil.copy(filename, path)
 
     def writable(self):
         if os.path.exists(self.filename):

--- a/src/backy/sources/__init__.py
+++ b/src/backy/sources/__init__.py
@@ -14,6 +14,9 @@ class BackySource(ABC):
     @abstractmethod
     def verify(self, target: "backy.backends.BackyBackend") -> bool: ...
 
+    def archive(self) -> None:
+        pass
+
 
 class BackySourceContext(ABC):
     @abstractmethod

--- a/src/backy/sources/ceph/rbd.py
+++ b/src/backy/sources/ceph/rbd.py
@@ -135,6 +135,9 @@ class RBDClient(object):
     def snap_rm(self, image):
         return self._rbd(["snap", "rm", image])
 
+    def snap_protect(self, image):
+        return self._rbd(["snap", "protect", image])
+
     @contextlib.contextmanager
     def export_diff(self, new: str, old: str) -> Iterator[RBDDiffV1]:
         if self._supports_whole_object:

--- a/src/backy/utils.py
+++ b/src/backy/utils.py
@@ -36,6 +36,8 @@ CHUNK_SIZE = 4 * MiB
 
 END = object()
 
+DEBUG = os.environ.get("BACKY_DEBUG") == "1"
+
 
 def report_status(f):
     def wrapped(*args, **kw):


### PR DESCRIPTION
Adds an environment variable to enable debug mode. This will enable extra logging, always trigger a full verify and archive all current revisions/ceph snapshots on an error.
(This is an environment variable instead of a config option, bc this is easier to read in the job specific subprocess (which does not read the main config))

Related issue(s): PL-133638

* [x] Change is documented in changelog

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
- [x] Security requirements tested? (EVIDENCE)
  - manually on patty
