### PR TITLE
[2.5.x] sources/ceph: support Pacific, drop Luminous/Jewel

### DIFF
--- a/changelog.d/20260319_123725_os_PL_135242_pacific_parsing.rst
+++ b/changelog.d/20260319_123725_os_PL_135242_pacific_parsing.rst
@@ -1,0 +1,3 @@
+.. A new scriv changelog fragment.
+
+- sources/ceph: drop special cases for Jewel and Luminous, start supporting Pacific (PL-135242)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ filter_files = true
 
 [tool.scriv]
 output_file = "CHANGES.txt"
+format = "rst"
 version = "literal: pyproject.toml: tool.poetry.version"
 entry_title_template = "{% if version %}{{ version }} {% endif %}({{ date.strftime('%Y-%m-%d') }})"
 categories = ""

--- a/src/backy/sources/ceph/rbd.py
+++ b/src/backy/sources/ceph/rbd.py
@@ -87,34 +87,18 @@ class RBDClient(object):
             raise
 
     def map(self, image, readonly=False):
-        def parse_mappings_pre_nautilus(mappings):
-            """The parser code for Ceph release Luminous and earlier."""
-            for mapping in mappings.values():
-                if image == "{pool}/{name}@{snap}".format(**mapping):
-                    return mapping
-            raise RuntimeError("Map not found in mapping list.")
-
-        def parse_mappings_since_nautilus(mappings):
+        def parse_mappings(mappings):
             """The parser code for Ceph release Nautilus and later."""
             for mapping in mappings:
                 if image == "{pool}/{name}@{snap}".format(**mapping):
                     return mapping
             raise RuntimeError("Map not found in mapping list.")
 
-        versionstring = self._rbd(["--version"])
-
         self._rbd(["map", image, "--read-only" if readonly else ""])
 
         mappings_raw = self._rbd(["showmapped"], format="json")
 
-        if "nautilus" in versionstring:
-            mapping = parse_mappings_since_nautilus(mappings_raw)
-        elif "luminous" in versionstring:
-            mapping = parse_mappings_pre_nautilus(mappings_raw)
-        else:
-            # our jewel build provides no version info
-            # this will break with releases newer than nautilus
-            mapping = parse_mappings_pre_nautilus(mappings_raw)
+        mapping = parse_mappings(mappings_raw)
 
         def scrub_mapping(mapping):
             SPEC = set(["pool", "name", "snap", "device"])

--- a/src/backy/sources/ceph/tests/conftest.py
+++ b/src/backy/sources/ceph/tests/conftest.py
@@ -174,41 +174,6 @@ class CephCLIBase:
         return imagedata
 
 
-class CephJewelCLI(CephCLIBase):
-    def __init__(self, tmpdir):
-        super().__init__(tmpdir)
-        self.mapped_images = {}
-
-    def version(self):
-        # This isn't really what happens in upstream but due to the way
-        # we built it on NixOS. Don't hurt the Ceph people.
-        return "ceph version Development (no_version)"
-
-    def unmap(self, device):
-        if not self._freeze_mapped:
-            for k, v in list(self.mapped_images.items()):
-                if device == v["device"]:
-                    del self.mapped_images[k]
-                    break
-            else:
-                raise subprocess.CalledProcessError(cmd="unmap", returncode=2)
-
-    def map(self, snapspec, read_only):
-        image = self._parse_snapspec(snapspec)
-        id = len(self.mapped_images)
-        image["device"] = f"{self.tmpdir}/rbd{id}"
-        if not self._freeze_mapped:
-            with open(image["device"], "a"):
-                pass
-            self.mapped_images[str(id)] = image
-        return ""
-
-
-class CephLuminousCLI(CephJewelCLI):
-    def version(self):
-        return "ceph version Development (no_version) luminous (stable)"
-
-
 class CephNautilusCLI(CephCLIBase):
     def __init__(self, tmpdir):
         super().__init__(tmpdir)
@@ -239,7 +204,12 @@ class CephNautilusCLI(CephCLIBase):
                 raise subprocess.CalledProcessError(cmd="unmap", returncode=2)
 
 
-@pytest.fixture(params=[CephJewelCLI, CephLuminousCLI, CephNautilusCLI])
+class CephPacificCLI(CephNautilusCLI):
+    def version(self):
+        return "ceph version 16.2.15 (618f440892089921c3e944a991122ddc44e60516) pacific (stable)"
+
+
+@pytest.fixture(params=[CephPacificCLI, CephNautilusCLI])
 def rbdclient(request, tmpdir, monkeypatch, log):
     client = RBDClient(log)
     client._supports_whole_object = True


### PR DESCRIPTION
As we do not need to support Ceph Jewel and Luminous anymore, we can remove the special parsing behaviour for these version. This allows us to drop explicit version string matching for now and use the Nautilus+ parsing format by default, giving us support for Ceph Pacific as well.

PL-135242

- [x] needs forward port to main
  - yes, but state of main is a bit undefined right now. Relevant PRs will be picked up once main branch development starts again.

Related issue(s): PL-XXXX, ...

* [x] Change is documented in changelog

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - none 
- [x] Security requirements tested? (EVIDENCE)
  - [x] tested successfully on a dev machine on Ceph pacific