### PR TITLE
[2.5.x] make whole object diff configurable

### DIFF
--- a/changelog.d/20251209_162100_whole_object_configurable.rst
+++ b/changelog.d/20251209_162100_whole_object_configurable.rst
@@ -1,0 +1,3 @@
+.. A new scriv changelog fragment.
+
+- Make whole object diff configurable (PL-134246)

--- a/src/backy/sources/ceph/rbd.py
+++ b/src/backy/sources/ceph/rbd.py
@@ -13,9 +13,16 @@ from .diff import RBDDiffV1
 
 class RBDClient(object):
     log: BoundLogger
+    use_whole_object_diff: bool
 
-    def __init__(self, log: BoundLogger):
+    def __init__(
+        self,
+        log: BoundLogger,
+        # disable by default due to performance issues when not using exclusive-lock in cluster (PL-134255)
+        use_whole_object_diff=False,
+    ):
         self.log = log.bind(subsystem="rbd")
+        self.use_whole_object_diff = use_whole_object_diff
 
     def _ceph_cli(self, cmdline, encoding="utf-8") -> str:
         # This wrapper function for the `rbd` command is only used for
@@ -67,6 +74,8 @@ class RBDClient(object):
 
     @functools.cached_property
     def _supports_whole_object(self):
+        if not self.use_whole_object_diff:
+            return False
         return "--whole-object" in self._rbd(["help", "export-diff"])
 
     def exists(self, snapspec):

--- a/src/backy/sources/ceph/source.py
+++ b/src/backy/sources/ceph/source.py
@@ -28,7 +28,9 @@ class CephRBD(BackySource, BackySourceFactory, BackySourceContext):
         self.image = config["image"]
         self.always_full = config.get("full-always", False)
         self.log = log.bind(subsystem="ceph")
-        self.rbd = RBDClient(self.log)
+        self.rbd = RBDClient(
+            self.log, config.get("use-full-object-diff", False)
+        )
 
     def ready(self) -> bool:
         """Check whether the source can be backed up.
@@ -146,8 +148,10 @@ class CephRBD(BackySource, BackySourceFactory, BackySourceContext):
             return backy.utils.files_are_roughly_equal(
                 source,
                 target,
-                report=lambda s, t, o: self.revision.backup.quarantine.add_report(
-                    QuarantineReport(s, t, o)
+                report=(
+                    lambda s, t, o: self.revision.backup.quarantine.add_report(
+                        QuarantineReport(s, t, o)
+                    )
                 ),
             )
 

--- a/src/backy/sources/ceph/tests/test_rbd.py
+++ b/src/backy/sources/ceph/tests/test_rbd.py
@@ -159,3 +159,36 @@ def test_rbd_export(popen, rbdclient, tmpdir):
             ),
         ]
     )
+
+
+RBD_HELP_WHOLE_OBJECT = """\
+usage: rbd export-diff [--pool <pool>] [--namespace <namespace>]
+                       [--image <image>] [--snap <snap>] [--path <path>]
+                       [--from-snap <from-snap>] [--whole-object]
+                       [--no-progress]
+                       <source-image-or-snap-spec> <path-name>
+"""
+
+
+def test_rbd_whole_object_support_detection(log):
+    rbd_mock = mock.Mock()
+    rbd_mock.return_value = RBD_HELP_WHOLE_OBJECT
+    client1 = RBDClient(log)  # assume default: `use_whole_object_diff=False`
+    client1._rbd = rbd_mock
+    assert not client1._supports_whole_object
+
+    client2 = RBDClient(log, use_whole_object_diff=False)
+    client2._rbd = rbd_mock
+    assert not client2._supports_whole_object
+
+    client3 = RBDClient(log, use_whole_object_diff=True)
+    client3._rbd = rbd_mock
+    assert client3._supports_whole_object
+
+    rbd_mock_no_whole_object = mock.Mock()
+    rbd_mock_no_whole_object.return_value = (
+        "usage: rbd export-diff [--pool <pool>] [--namespace <namespace>]"
+    )
+    client4 = RBDClient(log, use_whole_object_diff=True)
+    client4._rbd = rbd_mock_no_whole_object
+    assert not client4._supports_whole_object


### PR DESCRIPTION
Supersedes #89.

Related issue(s): PL-134246

* [x] Change is documented in changelog

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - encode the defaults and detection of whole-object diff availability in test cases
- [x] Security requirements tested? (EVIDENCE) 
