### PR TITLE
Pl 134275 whole object diff port to main

### DIFF
--- a/changelog.d/20251209_162100_whole_object_configurable.rst
+++ b/changelog.d/20251209_162100_whole_object_configurable.rst
@@ -1,0 +1,3 @@
+.. A new scriv changelog fragment.
+
+- Make whole object diff configurable (PL-134246)

--- a/src/backy/rbd/__init__.py
+++ b/src/backy/rbd/__init__.py
@@ -368,6 +368,7 @@ class CephRBD:
     rbd: RBDClient
     revision: Revision
     log: BoundLogger
+    use_full_object_diff: bool
 
     snapshot_timeout = 90
 
@@ -379,6 +380,7 @@ class CephRBD:
         vm: Optional[str] = None,
         consul_acl_token: Optional[str] = None,
         always_full: bool = False,
+        use_full_object_diff: bool = False,
     ):
         self.pool = pool
         self.image = image
@@ -386,7 +388,7 @@ class CephRBD:
         self.vm = vm
         self.consul_acl_token = consul_acl_token
         self.log = log.bind(subsystem="ceph")
-        self.rbd = RBDClient(self.log)
+        self.rbd = RBDClient(self.log, self.use_full_object_diff)
 
     @classmethod
     def from_config(cls, config: dict, log: BoundLogger) -> "CephRBD":
@@ -397,6 +399,7 @@ class CephRBD:
             config.get("vm"),
             config.get("consul_acl_token"),
             config.get("full-always", False),
+            config.get("use-full-object-diff", False),
         )
 
     def ready(self) -> bool:

--- a/src/backy/rbd/rbd.py
+++ b/src/backy/rbd/rbd.py
@@ -14,9 +14,16 @@ from backy.utils import CHUNK_SIZE
 
 class RBDClient(object):
     log: BoundLogger
+    use_whole_object_diff: bool
 
-    def __init__(self, log: BoundLogger):
+    def __init__(
+        self,
+        log: BoundLogger,
+        # disable by default due to performance issues when not using exclusive-lock in cluster (PL-134255)
+        use_whole_object_diff=False,
+    ):
         self.log = log.bind(subsystem="rbd")
+        self.use_whole_object_diff = use_whole_object_diff
 
     def _ceph_cli(self, cmdline, encoding="utf-8") -> str:
         # This wrapper function for the `rbd` command is only used for getting
@@ -67,6 +74,8 @@ class RBDClient(object):
 
     @functools.cached_property
     def _supports_whole_object(self):
+        if not self.use_whole_object_diff:
+            return False
         return "--whole-object" in self._rbd(["help", "export-diff"])
 
     def exists(self, snapspec: str):

--- a/src/backy/rbd/tests/test_rbd.py
+++ b/src/backy/rbd/tests/test_rbd.py
@@ -159,3 +159,36 @@ def test_rbd_export(popen, rbdclient, tmp_path):
             ),
         ]
     )
+
+
+RBD_HELP_WHOLE_OBJECT = """\
+usage: rbd export-diff [--pool <pool>] [--namespace <namespace>]
+                       [--image <image>] [--snap <snap>] [--path <path>]
+                       [--from-snap <from-snap>] [--whole-object]
+                       [--no-progress]
+                       <source-image-or-snap-spec> <path-name>
+"""
+
+
+def test_rbd_whole_object_support_detection(log):
+    rbd_mock = mock.Mock()
+    rbd_mock.return_value = RBD_HELP_WHOLE_OBJECT
+    client1 = RBDClient(log)  # assume default: `use_whole_object_diff=False`
+    client1._rbd = rbd_mock
+    assert not client1._supports_whole_object
+
+    client2 = RBDClient(log, use_whole_object_diff=False)
+    client2._rbd = rbd_mock
+    assert not client2._supports_whole_object
+
+    client3 = RBDClient(log, use_whole_object_diff=True)
+    client3._rbd = rbd_mock
+    assert client3._supports_whole_object
+
+    rbd_mock_no_whole_object = mock.Mock()
+    rbd_mock_no_whole_object.return_value = (
+        "usage: rbd export-diff [--pool <pool>] [--namespace <namespace>]"
+    )
+    client4 = RBDClient(log, use_whole_object_diff=True)
+    client4._rbd = rbd_mock_no_whole_object
+    assert not client4._supports_whole_object


### PR DESCRIPTION
Port of #98 to main branch.

Unfortunately, tests are already broken at the main branch-off commit, making this harder to test:

`24 failed, 263 passed, 1 skipped, 7 errors in 35.14s`

Related issue(s): PL-134246

* [x] Change is documented in changelog

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - encode the defaults and detection of whole-object diff availability in test cases
- [ ] Security requirements tested? (EVIDENCE)
  - [ ] ensure that tests pass
